### PR TITLE
Fix mod id for Trinkets Updated

### DIFF
--- a/src/main/java/me/pajic/tiered_backpacks/util/CompatFlags.java
+++ b/src/main/java/me/pajic/tiered_backpacks/util/CompatFlags.java
@@ -3,6 +3,6 @@ package me.pajic.tiered_backpacks.util;
 import me.pajic.tiered_backpacks.TieredBackpacks;
 
 public class CompatFlags {
-	public static final boolean TRINKETS_LOADED = TieredBackpacks.xplat().isModLoaded("trinkets-updated");
+	public static final boolean TRINKETS_LOADED = TieredBackpacks.xplat().isModLoaded("trinkets_updated");
 	public static final boolean SHULKER_BOX_TOOLTIP_LOADED = TieredBackpacks.xplat().isModLoaded("shulkerboxtooltip");
 }


### PR DESCRIPTION
Trinkets Updated changed its modid to allow for it to work on NeoForge.